### PR TITLE
Update requirements.txt

### DIFF
--- a/nearest-neighbor-dog-search/requirements.txt
+++ b/nearest-neighbor-dog-search/requirements.txt
@@ -3,3 +3,5 @@ weaviate-client==3.9.0
 Flask==2.2.2
 
 Pillow
+
+werkzeug==2.2.2


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. We can triage your pull request to the best possible team for review if you explain why you're making a change (or linking to a pull request) and what changes you've made.

See our [CONTRIBUTING.md](/CONTRIBUTING.md) for information how to contribute.

Thanks again!
-->

### Why:

default version of werkzeug returns error during run "python flask-app/application.py"
explicitly set werkzeug==2.2.2 helps

the error:
    from werkzeug.urls import url_quote
ImportError: cannot import name 'url_quote' from 'werkzeug.urls' (/usr/local/lib/python3.10/site-packages/werkzeug/urls.py)
