### PR TITLE
Update weaviate version in contextionary newspublication example

### DIFF
--- a/weaviate-contextionary-newspublications/docker-compose.yaml
+++ b/weaviate-contextionary-newspublications/docker-compose.yaml
@@ -9,17 +9,19 @@
       - '8080'
       - --scheme
       - http
-      image: semitechnologies/weaviate:1.9.0
+      image: cr.weaviate.io/semitechnologies/weaviate:1.27.2
       ports:
       - 8080:8080
+      - 50051:50051
       restart: on-failure:0
       environment:
         CONTEXTIONARY_URL: contextionary:9999
         QUERY_DEFAULTS_LIMIT: 25
         AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED: 'true'
         PERSISTENCE_DATA_PATH: '/var/lib/weaviate'
-        DEFAULT_VECTORIZER_MODULE: 'text2vec-contextionary'
         ENABLE_MODULES: 'text2vec-contextionary'
+        DEFAULT_VECTORIZER_MODULE: 'text2vec-contextionary'
+        CLUSTER_HOSTNAME: 'node1'
     contextionary:
       environment:
         OCCURRENCE_WEIGHT_LINEAR_FACTOR: 0.75
@@ -27,7 +29,7 @@
         EXTENSIONS_STORAGE_ORIGIN: http://weaviate:8080
         NEIGHBOR_OCCURRENCE_IGNORE_PERCENTILE: 5
         ENABLE_COMPOUND_SPLITTING: 'false'
-      image: semitechnologies/contextionary:en0.16.0-v1.0.2
+      image: semitechnologies/contextionary:en0.16.0-v1.2.1
       ports:
       - 9999:9999
     newspublications:

--- a/weaviate-contextionary-newspublications/readme.md
+++ b/weaviate-contextionary-newspublications/readme.md
@@ -1,7 +1,19 @@
 # Example docker-compose configuration file with text2vec-contextionary and demo dataset
 
-Here you find an example docker-compose configuration file to start up Weaviate with the [`text2vec-contextionary module`](https://www.semi.technology/developers/weaviate/current/modules/text2vec-contextionary.html) and a News Publications example dataset. 
+Here you find an example docker-compose configuration file to start up Weaviate with the [`text2vec-contextionary module`](https://weaviate.io/developers/weaviate/modules/text2vec-contextionary) and a News Publications example dataset. 
 
 ## How to use
 
-Download the `docker-compose.yml` file. In the folder where you stored the file, run `docker-compose up`. Now, Weaviate, the [`text2vec-contextionary module`](https://www.semi.technology/developers/weaviate/current/modules/text2vec-contextionary.html) and the demo dataset will be retrieved, Weaviate will start up with the text2vec-contextionary module, and load in the demo data. Weaviate will be running at `localhost:8080`. You can then navigate to [console.semi.technology](https://console.semi.technology/) and connect to `http://localhost:8080`, to query the dataset.
+Download the `docker-compose.yml` file. In the folder where you stored the file, run `docker-compose up`. Now, Weaviate, the [`text2vec-contextionary module`](https://weaviate.io/developers/weaviate/modules/text2vec-contextionary) and the demo dataset will be retrieved, Weaviate will start up with the text2vec-contextionary module, and load in the demo data. Weaviate will be running at `localhost:8080`. 
+
+You can then query the dataset with your favorite method. For example with the [python client](https://weaviate.io/developers/weaviate/client-libraries/python):
+
+```python
+import weaviate
+
+with weaviate.connect_to_local() as client:
+    articles = client.collections.get("Article")
+    response = articles.query.hybrid(query="Hockey",limit=2)
+    for o in response.objects:
+        print(o.properties)
+```


### PR DESCRIPTION
### Why:

This PR fixes: #67 

### What does your app/demo do?:

Loads the newspublication example using the contextionary vectorizer.

### How Has This Been Tested?
I updated the `docker-compose.yml` using the code provided in the [contextionary example](https://weaviate.io/developers/weaviate/modules/text2vec-contextionary#example)
Then I started the updated `docker-compose.yml` and successfully ran the following Python code with version 4.9.3 of the Python client library:
```python
import weaviate

with weaviate.connect_to_local() as client:
    articles = client.collections.get("Article")
    response = articles.query.hybrid(query="Hockey",limit=2)
    for o in response.objects:
        print(o.properties)
```

### Have you included a README.md file in your example?
I have adapted the existing README with to include the query example and updated outdated links.